### PR TITLE
implement scrollEventThrottle on ScrollView

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ export default class Carousel extends Component {
     onPageBeingChanged: PropTypes.func,
     swipe: PropTypes.bool,
     isLooped: PropTypes.bool,
+    scrollEventThrottle: PropTypes.number,
   };
 
   static defaultProps = {
@@ -80,6 +81,7 @@ export default class Carousel extends Component {
     onPageBeingChanged: undefined,
     swipe: true,
     isLooped: true,
+    scrollEventThrottle: 16,
   };
 
   constructor(props) {
@@ -400,6 +402,8 @@ export default class Carousel extends Component {
     };
 
     const { size, childrenLength } = this.state;
+    
+    const { scrollEventThrottle = 16 } = this.props;
 
     return (
       <View {...containerProps}>
@@ -408,6 +412,7 @@ export default class Carousel extends Component {
           onScrollBeginDrag={this._onScrollBegin}
           onMomentumScrollEnd={this._onScrollEnd}
           onScroll={this._onScroll}
+          scrollEventThrottle={scrollEventThrottle}
           alwaysBounceHorizontal={false}
           alwaysBounceVertical={false}
           contentInset={{ top: 0 }}


### PR DESCRIPTION
Fixes the **You specified `onScroll` on a `<ScrollView>` but not `scrollEventThrottle`. You will only receive one event. Using `16` you get all the events but be aware that it may cause frame drops, use a bigger number if you don't need as much precision.** log/warning/error message on iOS.